### PR TITLE
Fix SubscribeVehicleData general result in case of IGNORED

### DIFF
--- a/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
+++ b/src/components/application_manager/src/commands/mobile/subscribe_vehicle_data_request.cc
@@ -431,22 +431,26 @@ void SubscribeVehicleDataRequest::CheckVISubscribtions(
       out_info = "No data in the request";
     }
     out_result = false;
+    return;
   }
 
   if (0 == subscribed_items && !is_interface_not_available) {
     out_result_code = mobile_apis::Result::IGNORED;
     out_info = "Already subscribed on provided VehicleData.";
     out_result = false;
+    return;
   }
 
   if (is_everything_already_subscribed) {
-    out_result_code = vi_already_subscribed_by_this_app_.size()
-                          ? mobile_apis::Result::IGNORED
-                          : mobile_apis::Result::SUCCESS;
-    if (!(vi_already_subscribed_by_this_app_.empty())) {
+    if (vi_already_subscribed_by_this_app_.empty()) {
+      out_result_code = mobile_apis::Result::SUCCESS;
+      out_result = true;
+    } else {
+      out_result_code = mobile_apis::Result::IGNORED;
       out_info = "Already subscribed on some provided VehicleData.";
+      out_result = false;
     }
-    out_result = true;
+    return;
   }
 }
 


### PR DESCRIPTION
Fixed SubscribeVehicleData general result in case of IGNORED resultCode.
The problem was that result code for case when everyting is already subscribed
not set to false in case of IGNORED result.

In this commit:
- Updated output result for is_everything_already_subscribed case
- Added return to avoid redundant checks when output result already set